### PR TITLE
Add fn_ganancias_por_anio function to calculate monthly earnings for …

### DIFF
--- a/R2_ganaciasNetas.sql
+++ b/R2_ganaciasNetas.sql
@@ -43,3 +43,48 @@ END;
 $$ LANGUAGE plpgsql;
 
 SELECT * FROM ganancias_floristeria(2, '2023-01-01');
+
+CREATE OR REPLACE FUNCTION fn_ganancias_por_anio(
+  p_idFloristeria NUMERIC,
+  p_anio INT
+)
+RETURNS TABLE(
+  ganancias_brutas NUMERIC,
+  costos NUMERIC,
+  ganancias_netas NUMERIC,
+  mesdelanio VARCHAR
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  mes INT;
+  anioActual INT := EXTRACT(YEAR FROM CURRENT_DATE);
+  mesActual INT := EXTRACT(MONTH FROM CURRENT_DATE);
+  r RECORD;
+  meses TEXT[] := ARRAY['ene','feb','marzo','abr','may','jun','jul','ago','sep','oct','nov','dic'];
+BEGIN
+  IF p_anio < anioActual THEN
+    mesActual := 12;
+  ELSIF p_anio > anioActual THEN
+    RAISE NOTICE 'El año es mayor al actual, no se calcula.';
+    RETURN;
+  END IF;
+
+  FOR mes IN 1..mesActual LOOP
+    SELECT * INTO r
+    FROM ganancias_floristeria(
+      p_idFloristeria,
+      TO_DATE(p_anio::text || '-' || mes::text || '-01','YYYY-MM-DD')
+    );
+
+    ganancias_brutas := r.ganancias_brutas;
+    costos := r.costos;
+    ganancias_netas := r.ganancias_netas;
+    mesdelanio := meses[mes];
+
+    RETURN NEXT;
+  END LOOP;
+END;
+$$;
+
+SELECT * FROM fn_ganancias_por_anio(2,2023)

--- a/commands.sql
+++ b/commands.sql
@@ -2392,4 +2392,51 @@ $$ LANGUAGE plpgsql;
 
 SELECT * FROM ganancias_floristeria(2, '2023-01-01');
 
+/* Funcion adicional que llama la anterioir para los 12 meses del anio*/
+
+CREATE OR REPLACE FUNCTION fn_ganancias_por_anio(
+  p_idFloristeria NUMERIC,
+  p_anio INT
+)
+RETURNS TABLE(
+  ganancias_brutas NUMERIC,
+  costos NUMERIC,
+  ganancias_netas NUMERIC,
+  mesdelanio VARCHAR
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  mes INT;
+  anioActual INT := EXTRACT(YEAR FROM CURRENT_DATE);
+  mesActual INT := EXTRACT(MONTH FROM CURRENT_DATE);
+  r RECORD;
+  meses TEXT[] := ARRAY['ene','feb','marzo','abr','may','jun','jul','ago','sep','oct','nov','dic'];
+BEGIN
+  IF p_anio < anioActual THEN
+    mesActual := 12;
+  ELSIF p_anio > anioActual THEN
+    RAISE NOTICE 'El año es mayor al actual, no se calcula.';
+    RETURN;
+  END IF;
+
+  FOR mes IN 1..mesActual LOOP
+    SELECT * INTO r
+    FROM ganancias_floristeria(
+      p_idFloristeria,
+      TO_DATE(p_anio::text || '-' || mes::text || '-01','YYYY-MM-DD')
+    );
+
+    ganancias_brutas := r.ganancias_brutas;
+    costos := r.costos;
+    ganancias_netas := r.ganancias_netas;
+    mesdelanio := meses[mes];
+
+    RETURN NEXT;
+  END LOOP;
+END;
+$$;
+
+SELECT * FROM fn_ganancias_por_anio(2,2023)
+
 /* FIN DEL REQUERIMIENTO 2 */


### PR DESCRIPTION
This pull request introduces a new function to calculate yearly earnings for a flower shop. The function is added to two SQL files, `R2_ganaciasNetas.sql` and `commands.sql`.

New function implementation:

* [`R2_ganaciasNetas.sql`](diffhunk://#diff-588e4d911c2eff95f325d10378d8d9f04c0e9e0d3d62b2dce821b6a0b47ebe1dR46-R90): Added the `fn_ganancias_por_anio` function to calculate monthly earnings for a given year (`p_anio`) and flower shop ID (`p_idFloristeria`). The function returns a table with gross earnings, costs, net earnings, and the month of the year.
* [`commands.sql`](diffhunk://#diff-a8bba5fc7c1118fcbf58299f612d448f569a61c1f5efb73e538e1ab274764852R2395-R2441): Added the `fn_ganancias_por_anio` function with the same implementation as in `R2_ganaciasNetas.sql`. This function iterates through each month of the specified year and calculates the earnings.…a given year